### PR TITLE
fix: improve reliability and performances

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -26,3 +26,9 @@ pub const UART_AT_CMD: u8 = 0xAB;
 
 /// Interval in seconds between firmware update checks (3600 = 1 hour)
 pub const FIRMWARE_CHECK_INTERVAL: u64 = 3600;
+
+/// Watchdog timeout in seconds. Must be long enough to accommodate:
+/// - TLS 1.3 handshake (can take 10-20+ seconds on ESP32)
+/// - Sensor measurements (SCD30 data ready wait up to 30 seconds)
+/// - Network operations during poor connectivity
+pub const WATCHDOG_TIMEOUT_SECS: u64 = 60;

--- a/src/ota.rs
+++ b/src/ota.rs
@@ -1,5 +1,5 @@
-use alloc::boxed::Box;
 use alloc::format;
+use core::sync::atomic::{AtomicPtr, Ordering};
 use embassy_net::Stack;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 use embassy_time::Timer;
@@ -10,10 +10,17 @@ use esp_bootloader_esp_idf::{
 };
 use esp_storage::FlashStorage;
 use rand_chacha::ChaCha20Rng;
+use static_cell::StaticCell;
 
 use crate::config::CONFIG;
 use crate::constants::*;
 use crate::transport::Transport;
+
+/// Static buffer for OTA partition table operations to avoid heap allocation.
+/// This is shared across all OTA operations since they're serialized.
+static OTA_TABLE_BUFFER: StaticCell<[u8; PARTITION_TABLE_MAX_LEN]> = StaticCell::new();
+static OTA_TABLE_PTR: AtomicPtr<[u8; PARTITION_TABLE_MAX_LEN]> =
+    AtomicPtr::new(core::ptr::null_mut());
 
 #[derive(Debug)]
 pub enum Error {
@@ -24,7 +31,7 @@ pub enum Error {
     Config,     // Configuration errors
 }
 
-pub struct FirmwareUpdate<'a> {
+pub struct Ota<'a> {
     stack: &'static Mutex<NoopRawMutex, Stack<'static>>,
     rng: ChaCha20Rng,
     rx_buf: &'static Mutex<NoopRawMutex, [u8; RX_BUFFER_SIZE]>,
@@ -37,7 +44,7 @@ pub struct FirmwareUpdate<'a> {
     flash: FlashStorage<'a>,
 }
 
-impl<'a> FirmwareUpdate<'a> {
+impl<'a> Ota<'a> {
     pub fn new(
         stack: &'static Mutex<NoopRawMutex, Stack<'static>>,
         rng: ChaCha20Rng,
@@ -47,9 +54,12 @@ impl<'a> FirmwareUpdate<'a> {
         tls_write_buf: &'static Mutex<NoopRawMutex, [u8; TLS_BUFFER_MAX]>,
         mut flash: FlashStorage<'a>,
     ) -> Result<Self, Error> {
+        // Initialize static buffer for OTA operations
+        let table_buffer = OTA_TABLE_BUFFER.init([0u8; PARTITION_TABLE_MAX_LEN]);
+        OTA_TABLE_PTR.store(table_buffer as *mut _, Ordering::Release);
+
         // Mark app valid on startup
-        let mut buffer = Box::new([0u8; PARTITION_TABLE_MAX_LEN]);
-        let mut ota = OtaUpdater::new(&mut flash, &mut buffer).map_err(|_| Error::Ota)?;
+        let mut ota = OtaUpdater::new(&mut flash, table_buffer).map_err(|_| Error::Ota)?;
         ota.set_current_ota_state(OtaImageState::Valid).ok();
 
         let device_id = CONFIG.device_id;
@@ -77,8 +87,8 @@ impl<'a> FirmwareUpdate<'a> {
         let mut tls_read_buf = self.tls_read_buf.lock().await;
         let mut tls_write_buf = self.tls_write_buf.lock().await;
 
-        // Create transport session
-        let mut session = Box::new(Transport::new(
+        // Create transport session (stack-allocated, no Box needed)
+        let mut session = Transport::new(
             *stack_guard,
             &mut self.rng,
             &mut *rx_buf,
@@ -89,7 +99,10 @@ impl<'a> FirmwareUpdate<'a> {
             self.ota_port,
         )
         .await
-        .map_err(|_| Error::Connection)?);
+        .map_err(|e| {
+            log::error!("OTA transport connection failed: {:?}", e);
+            Error::Connection
+        })?;
 
         // Use a static string slice for the HTTP request template (optimized
         // for memory)
@@ -152,14 +165,38 @@ impl<'a> FirmwareUpdate<'a> {
         let mut lines = info_body.split(|&b| b == b'\n');
 
         // Version check with current version defined in Cargo package
-        let remote_version =
+        let remote_version_str =
             core::str::from_utf8(lines.next().ok_or(Error::Info)?).map_err(|_| Error::Info)?;
+        let remote_version_str = remote_version_str.trim();
 
-        if remote_version == VERSION {
-            log::info!(
-                "Already running latest version {}. Skipping update.",
-                VERSION
+        // Parse both versions as semver
+        let current_version = SemVer::parse(VERSION).ok_or_else(|| {
+            log::error!("Failed to parse current version '{}' as semver", VERSION);
+            Error::Info
+        })?;
+
+        let remote_version = SemVer::parse(remote_version_str).ok_or_else(|| {
+            log::error!(
+                "Failed to parse remote version '{}' as semver",
+                remote_version_str
             );
+            Error::Info
+        })?;
+
+        // Only update if remote version is strictly greater
+        if !remote_version.is_greater_than(&current_version) {
+            if remote_version == current_version {
+                log::info!(
+                    "Already running latest version {}. Skipping update.",
+                    VERSION
+                );
+            } else {
+                log::info!(
+                    "Remote version {} is not newer than current {}. Skipping update.",
+                    remote_version_str,
+                    VERSION
+                );
+            }
             return Ok(());
         }
 
@@ -168,15 +205,16 @@ impl<'a> FirmwareUpdate<'a> {
         let size = parse_number::<usize>(lines.next().ok_or(Error::Info)?)?;
 
         log::info!(
-            "OTA: server reports version={}, size={}",
-            remote_version,
+            "OTA: upgrading from {} to {} (size={} bytes)",
+            VERSION,
+            remote_version_str,
             size
         );
 
         // Drop session and create a new one for firmware download
         drop(session);
 
-        let mut session = Box::new(Transport::new(
+        let mut session = Transport::new(
             *stack_guard,
             &mut self.rng,
             &mut *rx_buf,
@@ -187,7 +225,10 @@ impl<'a> FirmwareUpdate<'a> {
             self.ota_port,
         )
         .await
-        .map_err(|_| Error::Connection)?);
+        .map_err(|e| {
+            log::error!("OTA firmware transport connection failed: {:?}", e);
+            Error::Connection
+        })?;
 
         // Same approach for firmware request
         const FIRMWARE_REQ_PREFIX: &str = "GET /firmware?device=";
@@ -240,10 +281,11 @@ impl<'a> FirmwareUpdate<'a> {
 
         let body_start = body_start.ok_or(Error::Firmware)?;
 
-        // Initialize OTA
-        let mut table_buffer = Box::new([0u8; PARTITION_TABLE_MAX_LEN]);
+        // Initialize OTA using the static table buffer
+        // SAFETY: OTA_TABLE_PTR was set in `new()` and OTA operations are serialized
+        let table_buffer = unsafe { &mut *OTA_TABLE_PTR.load(Ordering::Acquire) };
         let mut ota =
-            OtaUpdater::new(&mut self.flash, &mut table_buffer).map_err(|_| Error::Ota)?;
+            OtaUpdater::new(&mut self.flash, table_buffer).map_err(|_| Error::Ota)?;
 
         let (mut next_app_partition, _part_type) = ota.next_partition().map_err(|_| Error::Ota)?;
 
@@ -417,4 +459,142 @@ fn find_header_end(buf: &[u8]) -> Option<usize> {
     buf.windows(4)
         .position(|window| window == b"\r\n\r\n")
         .map(|pos| pos + 4)
+}
+
+/// Represents a parsed semantic version (major.minor.patch with optional pre-release)
+#[derive(Debug, PartialEq, Eq)]
+struct SemVer {
+    major: u32,
+    minor: u32,
+    patch: u32,
+    /// Pre-release identifier (e.g., "beta.0", "rc.1", "alpha")
+    /// None means it's a stable release
+    pre_release: Option<PreRelease>,
+}
+
+/// Pre-release version component
+#[derive(Debug, PartialEq, Eq)]
+struct PreRelease {
+    /// The type of pre-release (alpha, beta, rc, etc.)
+    kind: PreReleaseKind,
+    /// Optional numeric suffix (e.g., the "0" in "beta.0")
+    number: Option<u32>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+enum PreReleaseKind {
+    Alpha,
+    Beta,
+    Rc,
+    Other, // Unknown pre-release types sort after rc but before stable
+}
+
+impl PreRelease {
+    fn parse(s: &str) -> Option<Self> {
+        // Handle formats like "beta", "beta.0", "beta0", "rc.1", "rc1", "alpha"
+        let s = s.to_ascii_lowercase();
+
+        // Try to find a known pre-release kind
+        let (kind, remainder) = if s.starts_with("alpha") {
+            (PreReleaseKind::Alpha, &s[5..])
+        } else if s.starts_with("beta") {
+            (PreReleaseKind::Beta, &s[4..])
+        } else if s.starts_with("rc") {
+            (PreReleaseKind::Rc, &s[2..])
+        } else {
+            (PreReleaseKind::Other, s.as_str())
+        };
+
+        // Parse optional numeric suffix (handles ".0", "0", ".1", "1", etc.)
+        let number = if remainder.is_empty() {
+            None
+        } else {
+            let num_str = remainder.trim_start_matches('.');
+            num_str.parse().ok()
+        };
+
+        Some(PreRelease { kind, number })
+    }
+
+    /// Compare pre-releases. Returns Ordering.
+    fn cmp(&self, other: &PreRelease) -> core::cmp::Ordering {
+        use core::cmp::Ordering;
+
+        // First compare by kind (alpha < beta < rc < other)
+        match self.kind.cmp(&other.kind) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
+
+        // Then by number (None < Some(0) < Some(1) < ...)
+        match (&self.number, &other.number) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            (Some(a), Some(b)) => a.cmp(b),
+        }
+    }
+}
+
+impl SemVer {
+    /// Parse a semver string like "1.2.3", "v1.2.3", "1.2.3-beta", "v1.2.3-beta.0"
+    fn parse(version: &str) -> Option<Self> {
+        let version = version.trim();
+
+        // Strip optional 'v' or 'V' prefix
+        let version = version
+            .strip_prefix('v')
+            .or_else(|| version.strip_prefix('V'))
+            .unwrap_or(version);
+
+        // Split on '-' to separate version from pre-release
+        let (version_part, pre_release_part) = match version.split_once('-') {
+            Some((v, p)) => (v, Some(p)),
+            None => (version, None),
+        };
+
+        let mut parts = version_part.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next()?.parse().ok()?;
+
+        // Ensure no extra parts in version
+        if parts.next().is_some() {
+            return None;
+        }
+
+        let pre_release = pre_release_part.and_then(PreRelease::parse);
+
+        Some(SemVer {
+            major,
+            minor,
+            patch,
+            pre_release,
+        })
+    }
+
+    /// Returns true if self is greater than other
+    fn is_greater_than(&self, other: &SemVer) -> bool {
+        use core::cmp::Ordering;
+
+        // Compare major.minor.patch first
+        if self.major != other.major {
+            return self.major > other.major;
+        }
+        if self.minor != other.minor {
+            return self.minor > other.minor;
+        }
+        if self.patch != other.patch {
+            return self.patch > other.patch;
+        }
+
+        // Same major.minor.patch - compare pre-release
+        // A stable release (no pre-release) is greater than any pre-release
+        match (&self.pre_release, &other.pre_release) {
+            (None, None) => false,             // Equal
+            (None, Some(_)) => true,           // Stable > pre-release
+            (Some(_), None) => false,          // Pre-release < stable
+            (Some(a), Some(b)) => a.cmp(b) == Ordering::Greater,
+        }
+    }
 }

--- a/src/sensors/scd30.rs
+++ b/src/sensors/scd30.rs
@@ -2,12 +2,16 @@ use embassy_time::Delay;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::i2c::I2c;
 use libscd::asynchronous::scd30::Scd30 as Scd30Sensor;
-use log::info;
+use log::{info, error};
 
 use super::{Sensor, SensorData, SensorError};
 use crate::config::CONFIG;
 
 const AMBIENT_PRESSURE: u16 = 1013;
+/// Maximum number of retries for SCD30 initialization
+const MAX_INIT_RETRIES: u8 = 5;
+/// Maximum time to wait for sensor data to be ready (in milliseconds)
+const DATA_READY_TIMEOUT_MS: u64 = 30_000;
 
 pub struct Scd30<I2C> {
     sensor: Scd30Sensor<I2C, Delay>,
@@ -21,11 +25,17 @@ impl<I2C: I2c> Scd30<I2C> {
         Timer::after(Duration::from_millis(1000)).await;
 
         info!("Stopping continuous measurement...");
+        let mut retries = 0;
         loop {
             match sensor.stop_continuous_measurement().await {
                 Ok(_) => break,
                 Err(e) => {
-                    info!("Error occurred: {:?}. Retrying in 5 seconds...", e);
+                    retries += 1;
+                    if retries >= MAX_INIT_RETRIES {
+                        error!("SCD30: Failed to stop continuous measurement after {} retries: {:?}", MAX_INIT_RETRIES, e);
+                        return Err(SensorError::InitFailure);
+                    }
+                    info!("Error occurred: {:?}. Retry {}/{} in 5 seconds...", e, retries, MAX_INIT_RETRIES);
                     Timer::after(Duration::from_millis(5000)).await;
                 }
             }
@@ -35,15 +45,19 @@ impl<I2C: I2c> Scd30<I2C> {
         sensor
             .set_measurement_interval(CONFIG.measurement_interval_seconds)
             .await
-            .map_err(|_| SensorError::InitFailure)
-            .ok();
+            .map_err(|e| {
+                error!("SCD30: Failed to set measurement interval: {:?}", e);
+                SensorError::InitFailure
+            })?;
 
         Timer::after(Duration::from_millis(100)).await;
         sensor
             .start_continuous_measurement(AMBIENT_PRESSURE)
             .await
-            .map_err(|_| SensorError::InitFailure)
-            .ok();
+            .map_err(|e| {
+                error!("SCD30: Failed to start continuous measurement: {:?}", e);
+                SensorError::InitFailure
+            })?;
 
         info!("Initialised Scd30");
 
@@ -53,12 +67,23 @@ impl<I2C: I2c> Scd30<I2C> {
 
 impl<I2C: I2c> Sensor for Scd30<I2C> {
     async fn measure(&mut self, data: &mut SensorData) -> Result<(), SensorError> {
-        // Wait until data is ready
+        // Wait until data is ready with timeout
+        let start = embassy_time::Instant::now();
+        let timeout = Duration::from_millis(DATA_READY_TIMEOUT_MS);
+
         loop {
+            if start.elapsed() > timeout {
+                error!("SCD30: Timeout waiting for data ready after {}ms", DATA_READY_TIMEOUT_MS);
+                return Err(SensorError::MeasurementFailure);
+            }
+
             match self.sensor.data_ready().await {
                 Ok(true) => break,
                 Ok(false) => Timer::after(Duration::from_millis(100)).await,
-                Err(_) => return Err(SensorError::MeasurementFailure),
+                Err(e) => {
+                    error!("SCD30: Error checking data ready: {:?}", e);
+                    return Err(SensorError::MeasurementFailure);
+                }
             }
         }
 
@@ -69,7 +94,10 @@ impl<I2C: I2c> Sensor for Scd30<I2C> {
                 data.add_measurement("co2", sample.co2 as f32);
                 Ok(())
             }
-            Err(_) => Err(SensorError::MeasurementFailure),
+            Err(e) => {
+                error!("SCD30: Error reading measurement: {:?}", e);
+                Err(SensorError::MeasurementFailure)
+            }
         }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -10,7 +10,7 @@ use embassy_net::{
 };
 use embassy_time::Duration;
 use embedded_io_async::{ErrorType, Read, ReadExactError, Write};
-use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
+use embedded_tls::{Aes256GcmSha384, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
 #[cfg(feature = "mtls")]
 use p256::elliptic_curve::SecretKey;
 use rand_core::{CryptoRng, RngCore};
@@ -47,7 +47,7 @@ where
 }
 
 #[cfg(feature = "tls")]
-impl<'a> Transport<'a, TlsConnection<'a, TcpSocket<'a>, Aes128GcmSha256>> {
+impl<'a> Transport<'a, TlsConnection<'a, TcpSocket<'a>, Aes256GcmSha384>> {
     pub async fn new<RNG>(
         stack: Stack<'static>,
         rng: &mut RNG,
@@ -121,11 +121,11 @@ impl<'a> Transport<'a, TlsConnection<'a, TcpSocket<'a>, Aes128GcmSha256>> {
              log::info!("mTLS enabled: cert {} bytes, key {} bytes", _client_cert_der.len(), _client_key_der.len());
         }
 
-        let mut tls: TlsConnection<TcpSocket, Aes128GcmSha256> =
+        let mut tls: TlsConnection<TcpSocket, Aes256GcmSha384> =
             TlsConnection::new(socket, tls_read_buffer, tls_write_buffer);
 
-        log::info!("Starting TLS handshake with {} (TLS 1.3, AES-128-GCM-SHA256)", hostname);
-        let crypto_provider = UnsecureProvider::new::<Aes128GcmSha256>(rng);
+        log::info!("Starting TLS handshake with {} (TLS 1.3, AES-256-GCM-SHA384)", hostname);
+        let crypto_provider = UnsecureProvider::new::<Aes256GcmSha384>(rng);
         tls.open(TlsContext::new(&config, crypto_provider))
             .await
             .map_err(|e| {

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -15,7 +15,7 @@ use static_cell::StaticCell;
 
 use crate::config::CONFIG;
 
-static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+static RESOURCES: StaticCell<StackResources<5>> = StaticCell::new();
 
 pub struct Wifi {
     pub stack: Stack<'static>,


### PR DESCRIPTION
- fix socket exhaustion by properly closing TCP and TLS connections
- add a short delay after MQTT disconnect and increase stack resources to allow for more socket headroom
- rename FirmwareUpdate with OTA (since don't use esp-hal-ota anymore) and other improvements:
  - reuse a single TLS session
  - enable HTTP keep-alive
  - add real semver comparison
  - remove heap allocations
- improve SCD30 reliability with retry limits and a 30-second data-ready timeout
- increase watchdog timeout from 10 to 60 seconds to allow long TLS handshakes
- use compile-time feature gating (#[cfg()]) instead of runtime cfg!() checks